### PR TITLE
Remove SERVER_BASEPATH to fix kibana access

### DIFF
--- a/kubectl/instrumentation/kibana/kibana-deployment.yaml
+++ b/kubectl/instrumentation/kibana/kibana-deployment.yaml
@@ -23,8 +23,6 @@ spec:
             memory: 1Gi
             cpu: 200m
         env:
-          - name: "SERVER_BASEPATH"
-            value: "/api/v1/namespaces/instrumentation/services/kibana/proxy"
           - name: "NODE_OPTIONS"
             value: "--max-old-space-size=1000"
           - name: "ELASTICSEARCH_URL"


### PR DESCRIPTION
When SERVER_BASEPATH is specified, using kubectl port-forward does not
work, as every URL has /api/v1/namespaces/instrumentation/services/kibana/proxy
appended to it, and returns a 404