### PR TITLE
Add a common-environment for the apps namespace

### DIFF
--- a/kubectl/apps/apps-configmap.yaml
+++ b/kubectl/apps/apps-configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: common-environment
+    namespace: apps
+data:
+  JAVA_OPTS: "-XX:MaxRAMFraction=2 -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"


### PR DESCRIPTION
This allows to set some sensible defaults for containers in this
namespace. In this case for JAVA apps, JAVA_OPTS has some sensible
defaults.