### PR TITLE
Add elasticsearch-curator to clear down old logs

### DIFF
--- a/kubectl/instrumentation/elasticsearch/elasticsearch-curator-configmap.yaml
+++ b/kubectl/instrumentation/elasticsearch/elasticsearch-curator-configmap.yaml
@@ -1,0 +1,55 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: elasticsearch-curator
+  namespace: instrumentation
+data:
+  curator.yaml: |
+    ---
+    client:
+      hosts:
+        - elasticsearch
+      port: 9200
+      url_prefix:
+      use_ssl: False
+      certificate:
+      client_cert:
+      client_key:
+      ssl_no_validate: False
+      http_auth:
+      timeout: 30
+      master_only: False
+
+    logging:
+      loglevel: INFO
+      logfile:
+      logformat: default
+      blacklist: ['elasticsearch', 'urllib3']
+  actions.yaml: |
+    ---
+    # Remember, leave a key empty if there is no value.  None will be a string,
+    # not a Python "NoneType"
+    actions:
+      1:
+        action: delete_indices
+        description: >-
+          Delete indices older than 7 days (based on index name), for logstash-
+          prefixed indices. Ignore the error if the filter does not result in an
+          actionable list of indices (ignore_empty_list) and exit cleanly.
+        options:
+          ignore_empty_list: True
+          timeout_override:
+          continue_if_exception: False
+          disable_action: False
+        filters:
+        - filtertype: pattern
+          kind: prefix
+          value: logstash-
+          exclude:
+        - filtertype: age
+          source: name
+          direction: older
+          timestring: '%Y.%m.%d'
+          unit: days
+          unit_count: 7
+          exclude:

--- a/kubectl/instrumentation/elasticsearch/elasticsearch-curator-cron.yaml
+++ b/kubectl/instrumentation/elasticsearch/elasticsearch-curator-cron.yaml
@@ -1,0 +1,23 @@
+---
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: elasticsearch-curator
+  namespace: instrumentation
+spec:
+  schedule: "@daily"
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+            - name: curator
+              image: microdc/elasticsearch-curator:0.0.8
+              volumeMounts:
+                - name: config-volume
+                  mountPath: /etc/elasticsearch-curator
+          volumes:
+            - name: config-volume
+              configMap:
+                name: elasticsearch-curator
+          restartPolicy: OnFailure


### PR DESCRIPTION
- Add configmaps for curator settings
- add microdc/elasticsearch-curator image job in cron

tested on kops k8s cluster