### PR TITLE
Prometheus monitor alertmanager

### DIFF
--- a/metrics/alertmanager/alertmanager-service.yaml
+++ b/metrics/alertmanager/alertmanager-service.yaml
@@ -4,6 +4,7 @@ kind: Service
 metadata:
   labels:
     alertmanager: main
+    k8s-app: alertmanager
   name: alertmanager-main
   namespace: instrumentation
 spec:

--- a/metrics/kube-state-metrics/kube-state-metrics-deployment.yaml
+++ b/metrics/kube-state-metrics/kube-state-metrics-deployment.yaml
@@ -14,7 +14,7 @@ spec:
       serviceAccountName: kube-state-metrics
       containers:
         - name: kube-state-metrics
-          image: quay.io/coreos/kube-state-metrics:v0.5.0
+          image: quay.io/coreos/kube-state-metrics:v1.3.0
           ports:
             - name: metrics
               containerPort: 8080

--- a/metrics/prometheus/prometheus-k8s-service-monitor-alertmanager.yaml
+++ b/metrics/prometheus/prometheus-k8s-service-monitor-alertmanager.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: alertmanager
+  namespace: instrumentation
+  labels:
+    k8s-app: alertmanager
+spec:
+  jobLabel: k8s-app
+  selector:
+    matchLabels:
+      k8s-app: alertmanager
+  namespaceSelector:
+    matchNames:
+      - instrumentation
+  endpoints:
+    - port: web
+      interval: 30s
+      scrapeTimeout: 10s
+      path: /metrics


### PR DESCRIPTION
We have alerts logic for alerting if the alertmanager gets out of sync,
but this could never fire as previously we were never monitoring the
alertmanager.

How can you alert on the alertmanager if your monitoring doesn't have a
ServiceMonitor to monitor and alert on the AlertManager? :D