### PR TITLE
Replace ALL_NODES CPU graph with more sensible measurement

### DIFF
--- a/metrics/grafana/grafana-dashboards-data-configmap.yaml
+++ b/metrics/grafana/grafana-dashboards-data-configmap.yaml
@@ -92,10 +92,10 @@ data:
                         "steppedLine": false,
                         "targets": [
                             {
-                                "expr": "sum(rate(node_cpu{mode=\"idle\"}[2m])) * 100",
+                                "expr": "avg (sum (rate(node_cpu{mode=\"idle\"}[2m]) * 100) by (instance, cpu)) by (instance)",
                                 "hide": false,
                                 "intervalFactor": 10,
-                                "legendFormat": "",
+                                "legendFormat": "{{instance}}",
                                 "refId": "A",
                                 "step": 50
                             }


### PR DESCRIPTION
Instead of ~ 4000% reading, summing average percent of all instance CPU
usage together, here we split out per instance so you can see each
instance's average cpu used across all its cores.